### PR TITLE
Button up modal support for React portals to enable state-based viewer dialog.

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/common/components/modal-container.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/components/modal-container.js
@@ -71,7 +71,7 @@ class ModalContainer extends React.Component {
 						? this.props.modalItem.component
 						: null}
 				</div>
-				<div className="content" id={PORTAL_CONTAINER_DOM_ID} ref={this.onRefChanged}></div>
+				<div className="content portalContent" id={PORTAL_CONTAINER_DOM_ID} ref={this.onRefChanged}></div>
 			</div>
 		)
 	}

--- a/packages/app/obojobo-document-engine/src/scripts/common/components/modal-container.scss
+++ b/packages/app/obojobo-document-engine/src/scripts/common/components/modal-container.scss
@@ -34,19 +34,30 @@
 	animation-name: obojobo-draft--components--modal-container;
 
 	&.is-not-active {
-		// display: none;
 		animation: none;
 		pointer-events: none;
 		opacity: 0;
 	}
 
 	> .content {
-		position: absolute;
-		left: 50%;
-		top: 50%;
-		transform: translate(-50%, -50%);
 		animation-duration: $duration-animation-default;
 		animation-name: obojobo-draft--components--modal-container--content;
 		font-family: $font-default;
+
+		&:not(.portalContent) {
+			position: absolute;
+			left: 50%;
+			top: 50%;
+			transform: translate(-50%, -50%);
+		}
+
+		&.portalContent {
+			> * {
+				position: absolute;
+				left: 50%;
+				top: 50%;
+				transform: translate(-50%, -50%);
+			}
+		}
 	}
 }

--- a/packages/app/obojobo-document-engine/src/scripts/common/components/modal-container.scss
+++ b/packages/app/obojobo-document-engine/src/scripts/common/components/modal-container.scss
@@ -34,9 +34,9 @@
 	animation-name: obojobo-draft--components--modal-container;
 
 	&.is-not-active {
-		display: none;
-		// pointer-events: none;
-		// opacity: 0;
+		// display: none;
+		pointer-events: none;
+		opacity: 0;
 	}
 
 	> .content {

--- a/packages/app/obojobo-document-engine/src/scripts/common/components/modal-container.scss
+++ b/packages/app/obojobo-document-engine/src/scripts/common/components/modal-container.scss
@@ -35,6 +35,7 @@
 
 	&.is-not-active {
 		// display: none;
+		animation: none;
 		pointer-events: none;
 		opacity: 0;
 	}

--- a/packages/app/obojobo-document-engine/src/scripts/common/components/modal-portal.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/components/modal-portal.js
@@ -9,12 +9,13 @@ class ModalPortal extends React.Component {
 	}
 
 	render() {
-		const modalContainerEl = document.getElementById(Common.components.ModalContainer.PORTAL_CONTAINER_DOM_ID)
-
-		return ReactDOM.createPortal(
-			this.props.children,
-			modalContainerEl
+		const modalContainerEl = document.getElementById(
+			Common.components.ModalContainer.PORTAL_CONTAINER_DOM_ID
 		)
+
+		console.log('SUP HOMIE')
+
+		return modalContainerEl ? ReactDOM.createPortal(this.props.children, modalContainerEl) : null
 	}
 }
 

--- a/packages/app/obojobo-document-engine/src/scripts/common/components/modal-portal.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/components/modal-portal.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+import Common from 'obojobo-document-engine/src/scripts/common'
+
+class ModalPortal extends React.Component {
+	constructor(props) {
+		super(props)
+	}
+
+	render() {
+		const modalContainerEl = document.getElementById(Common.components.ModalContainer.PORTAL_CONTAINER_DOM_ID)
+
+		return ReactDOM.createPortal(
+			this.props.children,
+			modalContainerEl
+		)
+	}
+}
+
+export default ModalPortal

--- a/packages/app/obojobo-document-engine/src/scripts/common/components/modal-portal.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/components/modal-portal.js
@@ -13,8 +13,6 @@ class ModalPortal extends React.Component {
 			Common.components.ModalContainer.PORTAL_CONTAINER_DOM_ID
 		)
 
-		console.log('SUP HOMIE')
-
 		return modalContainerEl ? ReactDOM.createPortal(this.props.children, modalContainerEl) : null
 	}
 }

--- a/packages/app/obojobo-document-engine/src/scripts/common/index.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/index.js
@@ -15,6 +15,7 @@ import MockElement from './mockdom/mock-element'
 import MockTextNode from './mockdom/mock-text-node'
 import Modal from './components/modal/modal'
 import ModalContainer from './components/modal-container'
+import ModalPortal from './components/modal-portal'
 import ModalStore from './stores/modal-store'
 import ModalUtil from './util/modal-util'
 import MoreInfoButton from './components/more-info-button'
@@ -81,6 +82,7 @@ export default {
 			Prompt,
 			SimpleMessage,
 			Modal,
+			ModalPortal,
 			Dialog,
 			SimpleDialog,
 			ErrorDialog

--- a/packages/app/obojobo-document-engine/src/scripts/common/stores/modal-store.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/stores/modal-store.js
@@ -20,8 +20,8 @@ class ModalStore extends Store {
 	}
 
 	_getCurrentModal() {
-		return this.state.idOrder.length > 0
-			? this.state.modalsById[this.state.idOrder[this.state.idOrder.length - 1]]
+		return this.state.modals.length > 0
+			? this.state.modal[0]
 			: null
 	}
 

--- a/packages/app/obojobo-document-engine/src/scripts/common/stores/modal-store.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/stores/modal-store.js
@@ -6,9 +6,8 @@ class ModalStore extends Store {
 	constructor() {
 		super('modalstore')
 
-		Dispatcher.on('modal:show', (payload, status) => {
-			const id = this._show(payload.value)
-			status.id = id
+		Dispatcher.on('modal:show', payload => {
+			this._show(payload.value)
 		})
 
 		Dispatcher.on('modal:hide', this._hide.bind(this))
@@ -16,9 +15,7 @@ class ModalStore extends Store {
 
 	init() {
 		return (this.state = {
-			idOrder: [],
-			modalsById: {},
-			nextId: 1
+			modals: []
 		})
 	}
 
@@ -28,62 +25,20 @@ class ModalStore extends Store {
 			: null
 	}
 
-	_addModal(modalItem) {
-		const id = '' + this.state.nextId++
-
-		this.state.idOrder.push(id)
-
-		modalItem.id = id
-		modalItem.index = this.state.idOrder.length - 1
-		modalItem.lastActiveElement = document.activeElement
-
-		this.state.modalsById[id] = modalItem
-
-		return id
-	}
-
-	_removeModal(id) {
-		const modalItem = this.state.modalsById[id]
-
-		if (!modalItem) {
-			return false
-		}
-
-		delete this.state.modalsById[id]
-		this.state.idOrder.splice(modalItem.index, 1)
-
-		return true
-	}
-
 	_show(modalItem) {
-		// this.lastActiveElement = document.activeElement
-		// this.state.modals.push(modalItem)
-		// this.triggerChange()
-		const id = this._addModal(modalItem)
+		this.lastActiveElement = document.activeElement
+		this.state.modals.push(modalItem)
 		this.triggerChange()
-
-		return id
 	}
 
 	_hide() {
-		const currentModal = this._getCurrentModal()
+		this.state.modals.shift()
+		this.triggerChange()
 
-		if (!currentModal) {
-			return
+		if(this.lastActiveElement && document.body.contains(this.lastActiveElement)) {
+			focus(this.lastActiveElement)
 		}
-
-		if (this._removeModal(currentModal.id)) {
-			this.triggerChange()
-
-			if (
-				currentModal.lastActiveElement &&
-				document.body.contains(currentModal.lastActiveElement)
-			) {
-				focus(currentModal.lastActiveElement)
-			}
-
-			Dispatcher.trigger('modal:hidden', currentModal)
-		}
+		delete this.lastActiveElement
 	}
 
 	getState() {

--- a/packages/app/obojobo-document-engine/src/scripts/common/util/modal-util.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/util/modal-util.js
@@ -1,48 +1,21 @@
-import ReactDOM from 'react-dom'
-
 import Dispatcher from '../flux/dispatcher'
-import ModalContainer from '../components/modal-container'
 
 const ModalUtil = {
-	show(component, hideViewer = false, isPortal = false) {
-		// let portal = null
-
-		// if (isPortal) {
-		// 	portal = ReactDOM.createPortal(component, document.getElementById(ModalContainer.DOM_ID))
-		// }
-		// const portal = ReactDOM.createPortal(component, document.body)
-
-		// debugger
-		const status = {}
-		Dispatcher.trigger(
-			'modal:show',
-			{
-				value: { component, hideViewer, isPortal }
-			},
-			status
-		)
-
-		return status.id
-		// return portal
+	show(component, hideViewer = false) {
+		Dispatcher.trigger('modal:show',
+			{ value: { component, hideViewer }
+		})
 	},
 
 	hide() {
 		Dispatcher.trigger('modal:hide')
 	},
 
-	hasDialog(id, state) {
-		return typeof state.modalsById[id] !== 'undefined'
-	},
-
 	getCurrentModal(state) {
-		if (state.idOrder.length === 0) {
-			return null
-		}
-
-		return state.modalsById[state.idOrder[state.idOrder.length - 1]] || null
+		// return state.modalsById[state.idOrder[state.idOrder.length - 1]] || null
+		if (state.modals.length === 0) return null
+		return state.modals[0]
 	}
 }
-
-window.MU = ModalUtil
 
 export default ModalUtil

--- a/packages/app/obojobo-document-engine/src/scripts/common/util/state-machine-component.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/util/state-machine-component.js
@@ -2,12 +2,18 @@
 
 import React from 'react'
 
+import Common from 'obojobo-document-engine/src/scripts/common'
+const { SimpleDialog, ModalPortal } = Common.components.modal
+const { ModalUtil } = Common.util
+
 export default class Dialog extends React.Component {
 	constructor(props) {
 		super(props)
 
 		this.state = {
-			log: ''
+			log: '',
+			hackPortals: [],
+			showHackPortals: false
 		}
 
 		const originalOnTransition = props.machine.onTransition
@@ -44,6 +50,19 @@ export default class Dialog extends React.Component {
 		// this.forceUpdate()
 	}
 
+	alterHackPortals(remove=false) {
+		const hackPortalList = [ ...this.state.hackPortals ]
+		if (remove) {
+			hackPortalList.shift()
+		} else {
+			hackPortalList.push(<SimpleDialog title='HACK'>PORTAL HACK</SimpleDialog>)
+		}
+
+		this.setState({
+			hackPortals: hackPortalList
+		})
+	}
+
 	render() {
 		return (
 			<div
@@ -60,6 +79,36 @@ export default class Dialog extends React.Component {
 			>
 				{this.props.machine ? (
 					<div>
+						<button onClick={() => {
+							ModalUtil.show(
+								<SimpleDialog ok title='summoned-dialog'>
+									Spontaneously conjured dialog
+								</SimpleDialog>
+							)
+						}}>
+							Spawn Alert Dialog
+						</button>
+						<br/>
+						<button onClick={() => {this.alterHackPortals(true)}}>
+							Remove Hack Portal
+						</button>
+						<button onClick={() => {this.alterHackPortals()}}>
+							Add Hack Portal
+						</button>
+						<br/>
+						<button onClick={() => {this.setState({showHackPortals: !this.state.showHackPortals})}}>
+							Toggle Hack Portals
+						</button>
+						<br/>
+						{
+							this.state.showHackPortals ?
+								<ModalPortal>
+									{this.state.hackPortals}
+								</ModalPortal>
+							:
+								null
+						}
+						<br/>
 						<label>
 							<span>Step:</span>
 							<select value={this.props.machine.step} onChange={this.onChange.bind(this)}>

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/editor-app.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/editor-app.js
@@ -190,9 +190,10 @@ class EditorApp extends React.Component {
 		return (
 			<div className="visual-editor--editor-app">
 				{this.state.mode === VISUAL_MODE ? this.renderVisualEditor() : this.renderCodeEditor()}
-				{modalItem && modalItem.component ? (
+				{/* modalItem && modalItem.component ? (
 					<ModalContainer>{modalItem.component}</ModalContainer>
-				) : null}
+				) : null */}
+				<ModalContainer modalItem={modalItem} />
 			</div>
 		)
 	}

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/components/viewer-app.js
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/components/viewer-app.js
@@ -685,10 +685,10 @@ export default class ViewerApp extends React.Component {
 					</div>
 				) : null}
 				<FocusBlocker moduleData={this.state} />
-				{/* {true || (modalItem && modalItem.component) ? ( */}
-				{/* // <ModalContainer>{modalItem.component}</ModalContainer> */}
+				{/* modalItem && modalItem.component ? (
+					<ModalContainer>{modalItem.component}</ModalContainer>
+				) : null */}
 				<ModalContainer modalItem={modalItem} />
-				{/* ) : null} */}
 			</div>
 		)
 	}

--- a/packages/app/obojobo-document-json-parser/src/parsers/question-node-parser.js
+++ b/packages/app/obojobo-document-json-parser/src/parsers/question-node-parser.js
@@ -1,6 +1,5 @@
 const processAttrs = require('../process-attrs')
 const processTriggers = require('../process-triggers')
-const processAttrs = require('../process-attrs')
 
 const questionNodeParser = (node, childrenParser) => {
 	const id = node.id ? ` id="${node.id}"` : ''

--- a/packages/obonode/obojobo-sections-assessment/viewer-component.js
+++ b/packages/obonode/obojobo-sections-assessment/viewer-component.js
@@ -16,70 +16,12 @@ const { OboComponent, Throbber } = Viewer.components
 const { Dispatcher } = Common.flux
 const { ModalUtil } = Common.util
 const { ModalContainer } = Common.components
-const { SimpleDialog, Dialog } = Common.components.modal
+const { SimpleDialog, Dialog, ModalPortal } = Common.components.modal
 // const { Dialog } = Common.components.modal
 
 const { AssessmentUtil } = Viewer.util
 const { AssessmentNetworkStates } = Viewer.stores.assessmentStore
 const { NavUtil, FocusUtil, CurrentAssessmentStates } = Viewer.util
-
-class ModalPortal extends React.Component {
-	constructor(props) {
-		super(props)
-
-		this.state = {
-			todo: 0
-		}
-	}
-
-	// componentDidMount() {
-	// 	this.update()
-	// }
-
-	// componentDidUpdate() {
-	// 	this.update()
-	// }
-
-	// update() {
-	// 	if (!this.props.children) return
-
-	// 	const firstChild = this.props.children
-
-	// 	if(!this.props.children) {
-
-	// 	}
-
-	// 	if (firstChild !== this.state.component) {
-	// 		// if (this.state.component === null) {
-	// 		ModalUtil.show(null, false, true)
-	// 		// }
-
-	// 		this.setState({
-	// 			component: firstChild
-	// 		})
-	// 	}
-	// }
-
-	render() {
-		// alert('render')
-		// if (!document.getElementById(ModalContainer.PORTAL_CONTAINER_DOM_ID)) {
-		// 	alert('not ready')
-		// 	setTimeout(() => {
-		// 		this.setState({
-		// 			todo: this.state.todo + 1
-		// 		})
-		// 	}, 1000)
-
-		// 	return null
-		// }
-
-		return ReactDOM.createPortal(
-			this.props.children,
-			// document.getElementById(ModalContainer.PORTAL_CONTAINER_DOM_ID) //ModalContainer.DOM_ID
-			document.body //ModalContainer.DOM_ID
-		)
-	}
-}
 
 class Assessment extends React.Component {
 	constructor(props) {

--- a/packages/obonode/obojobo-sections-assessment/viewer-component.js
+++ b/packages/obonode/obojobo-sections-assessment/viewer-component.js
@@ -185,7 +185,7 @@ class Assessment extends React.Component {
 			this.props.model
 		)
 
-		ModalUtil.hide()
+		// ModalUtil.hide()
 		machine.gotoStep(AssessmentNetworkStates.TRYING_TO_SUBMIT)
 	}
 
@@ -193,7 +193,8 @@ class Assessment extends React.Component {
 		//@TODO: This needs to happen after sending success
 		AssessmentUtil.resetNetworkState(this.props.model)
 
-		ModalUtil.hide()
+		//this'll hide regular modals but has no affect on ModalPortal
+		// ModalUtil.hide()
 	}
 
 	onDialogResponse(response) {
@@ -204,7 +205,7 @@ class Assessment extends React.Component {
 					this.props.model
 				)
 
-				ModalUtil.hide()
+				// ModalUtil.hide()
 				machine.dispatch('tryResumeAttempt')
 
 				break


### PR DESCRIPTION
Closes #1301.

Rolled back some changes to ModalUtil, ModalStore and ModalContainer, left others. Pulled ModalPortal out of Assessment obonode and put it in the document engine to be made available through Common. Looks like all modals and the portal work together, barring any weird edge cases I haven't thought about.

Still a draft for now - there were a few other spots (`ModalContainer` notably) where it looks like there may be some leftover temporary/debug/development code that may or may not be important to keep around. May merit a little bit more review alongside double-checking this branch.